### PR TITLE
Update simulator in Makefile to work with Xcode 10.1 default simulator install.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ sort:
 	@perl ./bin/sortXcodeProject Succinct.xcodeproj/project.pbxproj
 
 unit-tests:
-	@/usr/bin/time xcodebuild -project Succinct.xcodeproj -scheme "Succinct" -destination "platform=iOS Simulator,OS=12.0,name=iPhone X" build test
+	@/usr/bin/time xcodebuild -project Succinct.xcodeproj -scheme "Succinct" -destination "platform=iOS Simulator,OS=12.1,name=iPhone XR" build test
 
 simulator-tests:
-	@/usr/bin/time xcodebuild -project Succinct.xcodeproj -scheme "SuccinctContainer" -destination "platform=iOS Simulator,OS=12.0,name=iPhone X" build test
+	@/usr/bin/time xcodebuild -project Succinct.xcodeproj -scheme "SuccinctContainer" -destination "platform=iOS Simulator,OS=12.1,name=iPhone XR" build test
 
 units tests: sort unit-tests
 


### PR DESCRIPTION
Hi @derekleerock! I noticed while trying to `make alltests`, the tests would not run with my install of Xcode 10.1. It seems to be because all simulators that come with Xcode are running iOS 12.1 but `xcodebuild` params specify 12.0.

The failure looks like this:
```
xcodebuild: error: Unable to find a destination matching the provided destination specifier:
		{ platform:iOS Simulator, OS:12.0, name:iPhone X }

	The requested device could not be found because no available devices matched the request.

	Available destinations for the "Succinct" scheme:
         [ .... all your devices and simulators ....]
```

This would probably be fine if I installed simulators running iOS 12.0. Given Xcode 10.1 is the current release version, how do you feel about updating the Makefile? __I've also changed the simulator from the iPhone X to the XR__ - mainly because this is the lowest spec of the current generation (and I think Xcode defaults to it on new projects). That's not strictly necessary to get the tests to run again, though.