### PR TITLE
Finds views inside of the view controller's navigation item title view

### DIFF
--- a/Succinct/UIViewController/UIViewController+UILabel.swift
+++ b/Succinct/UIViewController/UIViewController+UILabel.swift
@@ -11,6 +11,10 @@ extension UIViewController {
             return true
         }
 
+        if let titleView = navigationItem.titleView {
+            return titleView.hasLabel(withExactText: searchText)
+        }
+
         return navigationController?.hasLabelInNavigationBar(withExactText: searchText) ?? false
     }
 
@@ -21,6 +25,10 @@ extension UIViewController {
 
         if self.title?.contains(searchText) ?? false {
             return true
+        }
+
+        if let titleView = navigationItem.titleView {
+            return titleView.hasLabel(containingText: searchText)
         }
 
         return navigationController?.hasLabelInNavigationBar(containingText: searchText) ?? false
@@ -35,6 +43,10 @@ extension UIViewController {
             return labelInRootView
         }
 
+        if let titleView = navigationItem.titleView, let label = titleView.findLabel(withExactText: searchText) {
+            return label
+        }
+
         return navigationController?.findLabelInNavigationBar(withExactText: searchText)
     }
 
@@ -42,6 +54,10 @@ extension UIViewController {
         let labelInRootView = view.findLabel(containingText: searchText)
         if labelInRootView.isNotNil() {
             return labelInRootView
+        }
+
+        if let titleView = navigationItem.titleView, let label = titleView.findLabel(containingText: searchText) {
+            return label
         }
 
         return navigationController?.findLabelInNavigationBar(containingText: searchText)

--- a/SuccinctTests/Builders/UIViewControllerBuilder.swift
+++ b/SuccinctTests/Builders/UIViewControllerBuilder.swift
@@ -30,6 +30,11 @@ struct UIViewControllerBuilder {
         return self
     }
 
+    func withNavigationItemTitleView(_ titleView: UIView) -> UIViewControllerBuilder {
+        viewController.navigationItem.titleView = titleView
+        return self
+    }
+
     func withTitle(_ title: String) -> UIViewControllerBuilder {
         viewController.title = title
         return self

--- a/SuccinctTests/UIViewController/UIViewController+UILabelSpec.swift
+++ b/SuccinctTests/UIViewController/UIViewController+UILabelSpec.swift
@@ -91,6 +91,24 @@ final class UIViewController_UILabelSpec: QuickSpec {
                     expect(viewController.findLabel(withExactText: "Username:")).toNot(beNil())
                 }
             }
+
+            context("when a UILabel exists in the navigationItem's titleView") {
+                it("can be found") {
+                    let viewController = UIViewControllerBuilder()
+                        .withNavigationItemTitleView(
+                            UIViewBuilder().withSubview(
+                                UILabelBuilder()
+                                    .withTitleText("Navigation Title")
+                                    .build()
+                            )
+                            .build()
+                        )
+                        .build()
+
+
+                    expect(viewController.findLabel(withExactText: "Navigation Title")).toNot(beNil())
+                }
+            }
         }
 
         describe("has label by exact text") {
@@ -128,6 +146,24 @@ final class UIViewController_UILabelSpec: QuickSpec {
 
 
                     expect(viewController.hasLabel(withExactText: "Username:")).to(beTrue())
+                }
+            }
+
+            context("when a UILabel exists in the navigationItem's titleView") {
+                it("can be found") {
+                    let viewController = UIViewControllerBuilder()
+                        .withNavigationItemTitleView(
+                            UIViewBuilder().withSubview(
+                                UILabelBuilder()
+                                    .withTitleText("Navigation Title")
+                                    .build()
+                                )
+                                .build()
+                        )
+                        .build()
+
+
+                    expect(viewController.hasLabel(withExactText: "Navigation Title")).to(beTrue())
                 }
             }
         }
@@ -177,6 +213,24 @@ final class UIViewController_UILabelSpec: QuickSpec {
                     expect(result?.text).to(equal("Username:"))
                 }
             }
+
+            context("when a UILabel exists in the navigationItem's titleView") {
+                it("can be found") {
+                    let viewController = UIViewControllerBuilder()
+                        .withNavigationItemTitleView(
+                            UIViewBuilder().withSubview(
+                                UILabelBuilder()
+                                    .withTitleText("Navigation Title")
+                                    .build()
+                                )
+                                .build()
+                        )
+                        .build()
+
+
+                    expect(viewController.findLabel(containingText: "Navigation Title")).toNot(beNil())
+                }
+            }
         }
 
         describe("has label by containing text") {
@@ -217,6 +271,24 @@ final class UIViewController_UILabelSpec: QuickSpec {
 
 
                     expect(result).to(beTrue())
+                }
+            }
+
+            context("when a UILabel exists in the navigationItem's titleView") {
+                it("can be found") {
+                    let viewController = UIViewControllerBuilder()
+                        .withNavigationItemTitleView(
+                            UIViewBuilder().withSubview(
+                                UILabelBuilder()
+                                    .withTitleText("Navigation Title")
+                                    .build()
+                                )
+                                .build()
+                        )
+                        .build()
+
+
+                    expect(viewController.hasLabel(containingText: "Navigation Title")).to(beTrue())
                 }
             }
         }


### PR DESCRIPTION
I found that the navigationItem property on UIViewController is different than the one on the navigationController itself, and in order for my own tests using a custom titleView to pass with Succinct, I needed to check the navigationItem.titleView directly from the view controller. Therefore, I added a new case to the ViewController extension to check the navigationItem's titleView as well. 

Since this is on the UIViewController class I made the guess that this would be the right place to put it.  

Since the titleView stuff I wrote previously wasn't accomplishing what I needed, perhaps I should delete the titleView logic from the UINavigationController+UILabel part? Let me know your thoughts. 