### PR TITLE
Tapping multiple bar button items 

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "Quick/Nimble" "v8.0.1"
-github "Quick/Quick" "v2.0.0"
+github "Quick/Quick" "v2.1.0"

--- a/Succinct/UIViewController/UIViewController+UIBarButtonItem.swift
+++ b/Succinct/UIViewController/UIViewController+UIBarButtonItem.swift
@@ -1,6 +1,6 @@
 extension UIViewController {
     ///
-    /// Searches the view controller's `navigationItem.leftBarButtonIttem`, `navigationItem.rightBarButtonItem`, as well as the UIView hierarchy for a UIToolbar which may contain a UIBarButtonItem whose `SystemItem` matches the searchSystemItem and then attempts to tap the UIBarButtonItem by firing its associated target event, if one exists.
+    /// Searches the view controller's `navigationItem.leftBarButtonItem`, `navigationItem.rightBarButtonItem`, as well as the UIView hierarchy for a UIToolbar which may contain a UIBarButtonItem whose `SystemItem` matches the searchSystemItem and then attempts to tap the UIBarButtonItem by firing its associated target event, if one exists.
     ///
     /// This method is convenient for de-coupling from the details of where a UIBarButtonItem object may be located.
     ///
@@ -9,19 +9,26 @@ extension UIViewController {
     /// - Parameter searchSystemItem: `UIBarButtonItem.SystemItem` to compare to the UIBarButtonItem objects that are found.
     ///
     public func tapBarButtonItem(withSystemItem searchSystemItem: UIBarButtonItem.SystemItem) {
-        if let leftBarButtonItem = navigationItem.leftBarButtonItem {
-            if leftBarButtonItem.systemItem == searchSystemItem {
-                leftBarButtonItem.tap()
-            }
+        if let barButtonItem = navigationItem.findBarButtonItems(matchingCondition: { $0.systemItem == searchSystemItem }) {
+            barButtonItem.tap()
         }
 
-        if let rightBarButtonItem = navigationItem.rightBarButtonItem {
-            if rightBarButtonItem.systemItem == searchSystemItem {
-                rightBarButtonItem.tap()
-            }
+        if let barButtonItemInView = view.findBarButtonItem(systemItem: searchSystemItem) {
+            barButtonItemInView.tap()
         }
+    }
 
-        if let barButtonItem = view.findBarButtonItem(systemItem: searchSystemItem) {
+    ///
+    /// Searches the view controller's `navigationItem.leftBarButtonItem`, `navigationItem.rightBarButtonItem` which may contain a UIBarButtonItem whose `Title` matches the searchTitle and then attempts to tap the UIBarButtonItem by firing its associated target event, if one exists.
+    ///
+    /// This method is convenient for de-coupling from the details of where a UIBarButtonItem object may be located.
+    ///
+    /// - Note: Once an object is found matching the provided criteria the remainder of the view hierarchy is **not** searched.
+    ///
+    /// - Parameter searchTitle: `String` to compare to the Title strings that are found.
+    ///
+    public func tapBarButtonItem(withTitle searchTitle: String) {
+        if let barButtonItem = navigationItem.findBarButtonItems(matchingCondition: { $0.title == searchTitle}) {
             barButtonItem.tap()
         }
     }
@@ -42,5 +49,29 @@ extension UIViewController {
         if let rightBarButtonItem = navigationItem.rightBarButtonItem {
             rightBarButtonItem.tap()
         }
+    }
+
+    // MARK: - Finding Navigation Items
+}
+
+extension UINavigationItem {
+    public func findBarButtonItems(matchingCondition searchCondition: (_ item: UIBarButtonItem) -> Bool) -> UIBarButtonItem? {
+        if let leftBarButtonItems = leftBarButtonItems {
+            for item in leftBarButtonItems {
+                if searchCondition(item) {
+                    return item
+                }
+            }
+        }
+
+        if let rightBarButtonItems = rightBarButtonItems {
+            for item in rightBarButtonItems {
+                if searchCondition(item) {
+                    return item
+                }
+            }
+        }
+
+        return nil
     }
 }

--- a/Succinct/UIViewController/UIViewController+UIBarButtonItem.swift
+++ b/Succinct/UIViewController/UIViewController+UIBarButtonItem.swift
@@ -1,6 +1,6 @@
 extension UIViewController {
     ///
-    /// Searches the view controller's `navigationItem.leftBarButtonItem`, `navigationItem.rightBarButtonItem`, as well as the UIView hierarchy for a UIToolbar which may contain a UIBarButtonItem whose `SystemItem` matches the searchSystemItem and then attempts to tap the UIBarButtonItem by firing its associated target event, if one exists.
+    /// Searches the view controller's `navigationItem.leftBarButtonItems`, `navigationItem.rightBarButtonItems`, as well as the UIView hierarchy for a UIToolbar which may contain a UIBarButtonItem whose `SystemItem` matches the searchSystemItem and then attempts to tap the UIBarButtonItem by firing its associated target event, if one exists.
     ///
     /// This method is convenient for de-coupling from the details of where a UIBarButtonItem object may be located.
     ///
@@ -19,7 +19,7 @@ extension UIViewController {
     }
 
     ///
-    /// Searches the view controller's `navigationItem.leftBarButtonItem`, `navigationItem.rightBarButtonItem` which may contain a UIBarButtonItem whose `Title` matches the searchTitle and then attempts to tap the UIBarButtonItem by firing its associated target event, if one exists.
+    /// Searches the view controller's `navigationItem.leftBarButtonItems`, `navigationItem.rightBarButtonItems` which may contain a UIBarButtonItem whose `Title` matches the searchTitle and then attempts to tap the UIBarButtonItem by firing its associated target event, if one exists.
     ///
     /// This method is convenient for de-coupling from the details of where a UIBarButtonItem object may be located.
     ///
@@ -55,7 +55,7 @@ extension UIViewController {
 }
 
 extension UINavigationItem {
-    public func findBarButtonItems(matchingCondition searchCondition: (_ item: UIBarButtonItem) -> Bool) -> UIBarButtonItem? {
+    internal func findBarButtonItems(matchingCondition searchCondition: (_ item: UIBarButtonItem) -> Bool) -> UIBarButtonItem? {
         if let leftBarButtonItems = leftBarButtonItems {
             for item in leftBarButtonItems {
                 if searchCondition(item) {

--- a/SuccinctContainerTests/UIViewController/UIViewController+UIBarButtonItemSpec.swift
+++ b/SuccinctContainerTests/UIViewController/UIViewController+UIBarButtonItemSpec.swift
@@ -4,9 +4,14 @@ import Nimble
 
 final class UIViewController_UIBarButtonItemSpec: QuickSpec {
     private var buttonWasTapped: Bool = false
+    private var secondaryButtonWasTapped: Bool = false
 
     private func didTapBarButtonItem(_ sender: Any) {
         buttonWasTapped = true
+    }
+
+    private func didTapSecondBarButtonItem(_sender: Any) {
+        secondaryButtonWasTapped = true
     }
 
     override func spec() {
@@ -45,64 +50,136 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
             }
 
             describe("tapping system bar button items") {
-                it("can tap the *left* bar button item matching the specified system item") {
-                    let targetAction = TargetAction(self.didTapBarButtonItem)
+                context("when there is only one bar button item") {
+                    it("can tap the *left* bar button item matching the specified system item") {
+                        let targetAction = TargetAction(self.didTapBarButtonItem)
 
-                    let viewController = UIViewControllerBuilder()
-                        .withLeftBarButtonItem(systemItem: .add, targetAction: targetAction)
-                        .build()
-
-
-                    viewController.tapBarButtonItem(withSystemItem: .add)
+                        let viewController = UIViewControllerBuilder()
+                            .withLeftBarButtonItem(systemItem: .add, targetAction: targetAction)
+                            .build()
 
 
-                    expect(self.buttonWasTapped).to(beTrue())
+                        viewController.tapBarButtonItem(withSystemItem: .add)
+
+
+                        expect(self.buttonWasTapped).to(beTrue())
+                    }
+
+                    it("can tap the *right* bar button item matching the specified system item") {
+                        let targetAction = TargetAction(self.didTapBarButtonItem)
+
+                        let viewController = UIViewControllerBuilder()
+                            .withRightBarButtonItem(systemItem: .camera, targetAction: targetAction)
+                            .build()
+
+
+                        viewController.tapBarButtonItem(withSystemItem: .camera)
+
+
+                        expect(self.buttonWasTapped).to(beTrue())
+                    }
                 }
 
-                it("can tap the *right* bar button item matching the specified system item") {
-                    let targetAction = TargetAction(self.didTapBarButtonItem)
+                context("when there are multiple bar button items") {
+                    it("can tap the second *right* bar button item matching the specified system item") {
+                        let targetAction = TargetAction(self.didTapBarButtonItem)
+                        let otherAction = TargetAction(self.didTapSecondBarButtonItem)
 
-                    let viewController = UIViewControllerBuilder()
-                        .withRightBarButtonItem(systemItem: .camera, targetAction: targetAction)
-                        .build()
+                        let viewController = UIViewControllerBuilder()
+                            .withRightBarButtonItem(systemItem: .camera, targetAction: otherAction)
+                            .withRightBarButtonItem(systemItem: .add, targetAction: targetAction)
+                            .build()
 
 
-                    viewController.tapBarButtonItem(withSystemItem: .camera)
+                        viewController.tapBarButtonItem(withSystemItem: .add)
 
 
-                    expect(self.buttonWasTapped).to(beTrue())
+                        expect(self.buttonWasTapped).to(beTrue())
+                        expect(self.secondaryButtonWasTapped).to(beFalse())
+                    }
+
+                    it("can tap the second *left* bar button item matching the specified system item") {
+                        let targetAction = TargetAction(self.didTapBarButtonItem)
+                        let otherAction = TargetAction(self.didTapSecondBarButtonItem)
+
+                        let viewController = UIViewControllerBuilder()
+                            .withLeftBarButtonItem(systemItem: .add, targetAction: targetAction)
+                            .withLeftBarButtonItem(systemItem: .camera, targetAction: otherAction)
+                            .build()
+
+
+                        viewController.tapBarButtonItem(withSystemItem: .add)
+
+
+                        expect(self.buttonWasTapped).to(beTrue())
+                        expect(self.secondaryButtonWasTapped).to(beFalse())
+                    }
                 }
             }
 
-            describe("explicitly tapping the left bar button item that is not a system item") {
-                it("can tap the left bar button item") {
-                    let targetAction = TargetAction(self.didTapBarButtonItem)
+            describe("tapping bar button items with a title") {
+                context("when there is only one bar button item") {
+                    it("can tap the left bar button item") {
+                        let targetAction = TargetAction(self.didTapBarButtonItem)
 
-                    let viewController = UIViewControllerBuilder()
-                        .withLeftBarButtonItem(title: "Add", targetAction: targetAction)
-                        .build()
-
-
-                    viewController.tapLeftBarButtonItem()
+                        let viewController = UIViewControllerBuilder()
+                            .withLeftBarButtonItem(title: "Add", targetAction: targetAction)
+                            .build()
 
 
-                    expect(self.buttonWasTapped).to(beTrue())
+                        viewController.tapLeftBarButtonItem()
+
+
+                        expect(self.buttonWasTapped).to(beTrue())
+                    }
+
+                    it("can tap the right bar button item") {
+                        let targetAction = TargetAction(self.didTapBarButtonItem)
+
+                        let viewController = UIViewControllerBuilder()
+                            .withRightBarButtonItem(title: "Add", targetAction: targetAction)
+                            .build()
+
+
+                        viewController.tapRightBarButtonItem()
+
+
+                        expect(self.buttonWasTapped).to(beTrue())
+                    }
                 }
-            }
 
-            describe("explicitly tapping the right bar button item that is not a system item") {
-                it("can tap the right bar button item") {
-                    let targetAction = TargetAction(self.didTapBarButtonItem)
+                context("when there are multiple bar button items") {
+                    it("can tap the left bar button item") {
+                        let targetAction = TargetAction(self.didTapBarButtonItem)
+                        let otherAction = TargetAction(self.didTapSecondBarButtonItem)
 
-                    let viewController = UIViewControllerBuilder()
-                        .withRightBarButtonItem(title: "Add", targetAction: targetAction)
-                        .build()
-
-
-                    viewController.tapRightBarButtonItem()
+                        let viewController = UIViewControllerBuilder()
+                            .withLeftBarButtonItem(title: "Add", targetAction: targetAction)
+                            .withLeftBarButtonItem(title: "Camera", targetAction: otherAction)
+                            .build()
 
 
-                    expect(self.buttonWasTapped).to(beTrue())
+                        viewController.tapBarButtonItem(withTitle: "Add")
+
+
+                        expect(self.buttonWasTapped).to(beTrue())
+                    }
+
+                    it("can tap the right bar button item") {
+                        let targetAction = TargetAction(self.didTapBarButtonItem)
+                        let otherAction = TargetAction(self.didTapSecondBarButtonItem)
+
+                        let viewController = UIViewControllerBuilder()
+                            .withRightBarButtonItem(title: "Add", targetAction: targetAction)
+                            .withRightBarButtonItem(title: "Camera", targetAction: otherAction)
+                            .build()
+
+
+                        viewController.tapBarButtonItem(withTitle: "Add")
+
+
+                        expect(self.buttonWasTapped).to(beTrue())
+                    }
                 }
             }
             

--- a/SuccinctContainerTests/UIViewController/UIViewController+UIBarButtonItemSpec.swift
+++ b/SuccinctContainerTests/UIViewController/UIViewController+UIBarButtonItemSpec.swift
@@ -3,15 +3,15 @@ import Nimble
 @testable import Succinct
 
 final class UIViewController_UIBarButtonItemSpec: QuickSpec {
-    private var buttonWasTapped: Bool = false
-    private var secondaryButtonWasTapped: Bool = false
+    private var firstButtonWasTapped: Bool = false
+    private var secondButtonWasTapped: Bool = false
 
-    private func didTapBarButtonItem(_ sender: Any) {
-        buttonWasTapped = true
+    private func didTapFirstBarButtonItem(_ sender: Any) {
+        firstButtonWasTapped = true
     }
 
     private func didTapSecondBarButtonItem(_sender: Any) {
-        secondaryButtonWasTapped = true
+        secondButtonWasTapped = true
     }
 
     override func spec() {
@@ -19,7 +19,7 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
             var viewController: UIViewController!
 
             beforeEach {
-                self.buttonWasTapped = false
+                self.firstButtonWasTapped = false
             }
 
             context("when there are no bar button items") {
@@ -31,28 +31,28 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
                     viewController.tapBarButtonItem(withSystemItem: .add)
 
 
-                    expect(self.buttonWasTapped).to(beFalse())
+                    expect(self.firstButtonWasTapped).to(beFalse())
                 }
 
                 it("cannot tap the left bar button item") {
                     viewController.tapLeftBarButtonItem()
 
 
-                    expect(self.buttonWasTapped).to(beFalse())
+                    expect(self.firstButtonWasTapped).to(beFalse())
                 }
 
                 it("cannot tap the right bar button item") {
                     viewController.tapRightBarButtonItem()
 
 
-                    expect(self.buttonWasTapped).to(beFalse())
+                    expect(self.firstButtonWasTapped).to(beFalse())
                 }
             }
 
             describe("tapping system bar button items") {
                 context("when there is only one bar button item") {
                     it("can tap the *left* bar button item matching the specified system item") {
-                        let targetAction = TargetAction(self.didTapBarButtonItem)
+                        let targetAction = TargetAction(self.didTapFirstBarButtonItem)
 
                         let viewController = UIViewControllerBuilder()
                             .withLeftBarButtonItem(systemItem: .add, targetAction: targetAction)
@@ -62,11 +62,11 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
                         viewController.tapBarButtonItem(withSystemItem: .add)
 
 
-                        expect(self.buttonWasTapped).to(beTrue())
+                        expect(self.firstButtonWasTapped).to(beTrue())
                     }
 
                     it("can tap the *right* bar button item matching the specified system item") {
-                        let targetAction = TargetAction(self.didTapBarButtonItem)
+                        let targetAction = TargetAction(self.didTapFirstBarButtonItem)
 
                         let viewController = UIViewControllerBuilder()
                             .withRightBarButtonItem(systemItem: .camera, targetAction: targetAction)
@@ -76,13 +76,13 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
                         viewController.tapBarButtonItem(withSystemItem: .camera)
 
 
-                        expect(self.buttonWasTapped).to(beTrue())
+                        expect(self.firstButtonWasTapped).to(beTrue())
                     }
                 }
 
                 context("when there are multiple bar button items") {
                     it("can tap the second *right* bar button item matching the specified system item") {
-                        let targetAction = TargetAction(self.didTapBarButtonItem)
+                        let targetAction = TargetAction(self.didTapFirstBarButtonItem)
                         let otherAction = TargetAction(self.didTapSecondBarButtonItem)
 
                         let viewController = UIViewControllerBuilder()
@@ -94,12 +94,12 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
                         viewController.tapBarButtonItem(withSystemItem: .add)
 
 
-                        expect(self.buttonWasTapped).to(beTrue())
-                        expect(self.secondaryButtonWasTapped).to(beFalse())
+                        expect(self.firstButtonWasTapped).to(beTrue())
+                        expect(self.secondButtonWasTapped).to(beFalse())
                     }
 
                     it("can tap the second *left* bar button item matching the specified system item") {
-                        let targetAction = TargetAction(self.didTapBarButtonItem)
+                        let targetAction = TargetAction(self.didTapFirstBarButtonItem)
                         let otherAction = TargetAction(self.didTapSecondBarButtonItem)
 
                         let viewController = UIViewControllerBuilder()
@@ -111,8 +111,8 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
                         viewController.tapBarButtonItem(withSystemItem: .add)
 
 
-                        expect(self.buttonWasTapped).to(beTrue())
-                        expect(self.secondaryButtonWasTapped).to(beFalse())
+                        expect(self.firstButtonWasTapped).to(beTrue())
+                        expect(self.secondButtonWasTapped).to(beFalse())
                     }
                 }
             }
@@ -120,7 +120,7 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
             describe("tapping bar button items with a title") {
                 context("when there is only one bar button item") {
                     it("can tap the left bar button item") {
-                        let targetAction = TargetAction(self.didTapBarButtonItem)
+                        let targetAction = TargetAction(self.didTapFirstBarButtonItem)
 
                         let viewController = UIViewControllerBuilder()
                             .withLeftBarButtonItem(title: "Add", targetAction: targetAction)
@@ -130,11 +130,11 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
                         viewController.tapLeftBarButtonItem()
 
 
-                        expect(self.buttonWasTapped).to(beTrue())
+                        expect(self.firstButtonWasTapped).to(beTrue())
                     }
 
                     it("can tap the right bar button item") {
-                        let targetAction = TargetAction(self.didTapBarButtonItem)
+                        let targetAction = TargetAction(self.didTapFirstBarButtonItem)
 
                         let viewController = UIViewControllerBuilder()
                             .withRightBarButtonItem(title: "Add", targetAction: targetAction)
@@ -144,13 +144,13 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
                         viewController.tapRightBarButtonItem()
 
 
-                        expect(self.buttonWasTapped).to(beTrue())
+                        expect(self.firstButtonWasTapped).to(beTrue())
                     }
                 }
 
                 context("when there are multiple bar button items") {
                     it("can tap the left bar button item") {
-                        let targetAction = TargetAction(self.didTapBarButtonItem)
+                        let targetAction = TargetAction(self.didTapFirstBarButtonItem)
                         let otherAction = TargetAction(self.didTapSecondBarButtonItem)
 
                         let viewController = UIViewControllerBuilder()
@@ -162,11 +162,11 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
                         viewController.tapBarButtonItem(withTitle: "Add")
 
 
-                        expect(self.buttonWasTapped).to(beTrue())
+                        expect(self.firstButtonWasTapped).to(beTrue())
                     }
 
                     it("can tap the right bar button item") {
-                        let targetAction = TargetAction(self.didTapBarButtonItem)
+                        let targetAction = TargetAction(self.didTapFirstBarButtonItem)
                         let otherAction = TargetAction(self.didTapSecondBarButtonItem)
 
                         let viewController = UIViewControllerBuilder()
@@ -178,7 +178,7 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
                         viewController.tapBarButtonItem(withTitle: "Add")
 
 
-                        expect(self.buttonWasTapped).to(beTrue())
+                        expect(self.firstButtonWasTapped).to(beTrue())
                     }
                 }
             }
@@ -194,7 +194,7 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
                         viewController.tapBarButtonItem(withSystemItem: .camera)
 
 
-                        expect(self.buttonWasTapped).to(beFalse())
+                        expect(self.firstButtonWasTapped).to(beFalse())
                     }
                 }
 
@@ -208,13 +208,13 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
                         viewController.tapBarButtonItem(withSystemItem: .camera)
 
 
-                        expect(self.buttonWasTapped).to(beFalse())
+                        expect(self.firstButtonWasTapped).to(beFalse())
                     }
                 }
 
                 context("When there is no matching UIBarButtonItem") {
                     it("cannot tap the bar button item") {
-                        let targetAction = TargetAction(self.didTapBarButtonItem)
+                        let targetAction = TargetAction(self.didTapFirstBarButtonItem)
 
                         let toolbar = UIToolbarBuilder()
                             .withBarButtonItem(systemItem: .done, targetAction: targetAction)
@@ -228,13 +228,13 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
                         viewController.tapBarButtonItem(withSystemItem: .camera)
 
 
-                        expect(self.buttonWasTapped).to(beFalse())
+                        expect(self.firstButtonWasTapped).to(beFalse())
                     }
                 }
 
                 context("when the toolbar is configured in a text view") {
                     it("can tap the bar button item") {
-                        let targetAction = TargetAction(self.didTapBarButtonItem)
+                        let targetAction = TargetAction(self.didTapFirstBarButtonItem)
 
                         let toolbar = UIToolbarBuilder()
                             .withBarButtonItem(systemItem: .camera, targetAction: targetAction)
@@ -248,13 +248,13 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
                         viewController.tapBarButtonItem(withSystemItem: .camera)
 
 
-                        expect(self.buttonWasTapped).to(beTrue())
+                        expect(self.firstButtonWasTapped).to(beTrue())
                     }
                 }
 
                 context("when the toolbar is in the second subview") {
                     it("can tap the bar button item") {
-                        let targetAction = TargetAction(self.didTapBarButtonItem)
+                        let targetAction = TargetAction(self.didTapFirstBarButtonItem)
 
                         let toolbar = UIToolbarBuilder()
                             .withBarButtonItem(systemItem: .camera, targetAction: targetAction)
@@ -268,7 +268,7 @@ final class UIViewController_UIBarButtonItemSpec: QuickSpec {
                         viewController.tapBarButtonItem(withSystemItem: .camera)
 
 
-                        expect(self.buttonWasTapped).to(beTrue())
+                        expect(self.firstButtonWasTapped).to(beTrue())
                     }
                 }
             }

--- a/Test Infrastructure/Builders/UIViewControllerBuilder.swift
+++ b/Test Infrastructure/Builders/UIViewControllerBuilder.swift
@@ -49,8 +49,8 @@ struct UIViewControllerBuilder {
             target: targetAction,
             action: #selector(TargetAction.action(sender:))
         )
-        
-        viewController.navigationItem.leftBarButtonItem = barButtonItem
+
+        viewController.navigationItem.addLeftBarButtonItem(barButtonItem)
         
         return self
     }
@@ -66,7 +66,7 @@ struct UIViewControllerBuilder {
             action: #selector(TargetAction.action(sender:))
         )
 
-        viewController.navigationItem.leftBarButtonItem = barButtonItem
+        viewController.navigationItem.addLeftBarButtonItem(barButtonItem)
 
         return self
     }
@@ -80,8 +80,8 @@ struct UIViewControllerBuilder {
             target: targetAction,
             action: #selector(TargetAction.action(sender:))
         )
-        
-        viewController.navigationItem.rightBarButtonItem = barButtonItem
+
+        viewController.navigationItem.addRightBarButtonItem(barButtonItem)
         
         return self
     }
@@ -97,12 +97,30 @@ struct UIViewControllerBuilder {
             action: #selector(TargetAction.action(sender:))
         )
 
-        viewController.navigationItem.rightBarButtonItem = barButtonItem
+        viewController.navigationItem.addRightBarButtonItem(barButtonItem)
 
         return self
     }
 
     func build() -> UIViewController {
         return viewController
+    }
+}
+
+private extension UINavigationItem {
+    func addLeftBarButtonItem(_ item: UIBarButtonItem) {
+        if leftBarButtonItems.isNil() {
+            leftBarButtonItems = []
+        }
+
+        leftBarButtonItems?.append(item)
+    }
+
+    func addRightBarButtonItem(_ item: UIBarButtonItem) {
+        if rightBarButtonItems.isNil() {
+            rightBarButtonItems = []
+        }
+
+        rightBarButtonItems?.append(item)
     }
 }


### PR DESCRIPTION
I took a first pass at adding the ability to tap multiple bar button items in the navigation bar. I also added the ability to tap them based on either the title or the system item. In my case I had two icons in the rightBarButtonItems I needed to tap.

Im not sure if there are rules I should be aware of with the comments above the public functions. I tried to follow the style you had for the tapBarButtonItem(systemItem:) function. Let me know how this works.