### PR TITLE
Add support for Swift Package Manager to Succinct

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,32 @@
+// swift-tools-version:5.5
+
+import PackageDescription
+
+let package = Package(
+    name: "Succinct",
+    platforms: [
+        .iOS(.v12)
+    ],
+    products: [
+        .library(
+            name: "Succinct",
+            targets: ["Succinct"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "Succinct",
+            path: "Succinct",
+            exclude: ["Info.plist"]
+        ),
+        .testTarget(
+            name: "SuccinctTests",
+            dependencies: ["Succinct"],
+            path: "SuccinctTests",
+            exclude: ["Info.plist"],
+            resources: [
+                .copy("Resources/TestImages.xcassets")
+            ]
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ target 'MyAmazingApp' do
 end
 ```
 
+## Swift Package Manager
+
+In Xcode, select the `File -> Add Packages...` menu option and enter `https://github.com/derekleerock/Succinct` for the the repository URL. Select the desired Dependency Rule and Target then click "Add Package"
+
+
 # Documentation
 [ 📄 Documentation via GitHubPages](https://derekleerock.github.io/Succinct/)
 

--- a/Succinct.xcodeproj/project.pbxproj
+++ b/Succinct.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		5B6AD15A4AC038FBB05E01FC /* DebugLogging+UIPickerViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DebugLogging+UIPickerViewSpec.swift"; sourceTree = "<group>"; };
 		5B6AD1B2557FA9D911BCD269 /* DebugLogging+UIButtonSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "DebugLogging+UIButtonSpec.swift"; sourceTree = "<group>"; };
 		8F6F2D5C21EEF3DF0004BFA3 /* UIView+UIDatePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+UIDatePickerView.swift"; sourceTree = "<group>"; };
+		9764B38E272F822500B9FECC /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = SOURCE_ROOT; };
 		AE3CCDCA21F5742F00A3638D /* UIViewController+MKMapViewSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+MKMapViewSpec.swift"; sourceTree = "<group>"; };
 		AE3CCDCD21F58A7400A3638D /* UIViewController+MKMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+MKMapView.swift"; sourceTree = "<group>"; };
 		AE3CCDCF21F58BE400A3638D /* MapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
@@ -495,6 +496,7 @@
 				52C1E5152541BE4C00A207E8 /* .gitignore */,
 				525F5AA82407EECA0039F42A /* .travis.yml */,
 				52C1E5172541C3A900A207E8 /* Gemfile.lock */,
+				9764B38E272F822500B9FECC /* Package.swift */,
 				B8FE917E2120F5F30097274D /* README.md */,
 				52C1E5162541C3A800A207E8 /* Succinct.podspec */,
 			);

--- a/Succinct/Condition/SuccinctCondition.swift
+++ b/Succinct/Condition/SuccinctCondition.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 ///
 /// A SuccinctCondition encapsulates the conditional logic that should be applied when evaluating a UIView. The evaluation of this condition returns an EvaluationResult object which can indicate not only if the UIView met the specified condition, but for instances when the condition is not met then additional information can be communicated.
 ///

--- a/Succinct/Configuration/SuccinctConfig.swift
+++ b/Succinct/Configuration/SuccinctConfig.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 ///
 /// Object which allows access to cofigurable options within Succinct.
 ///

--- a/Succinct/DebugLog/ViewHierarchyLogger.swift
+++ b/Succinct/DebugLog/ViewHierarchyLogger.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 public protocol ViewHierarchyLogger {
     func logEnterParentView(_ view: UIView)
     func logExitParentView(_ view: UIView)

--- a/Succinct/Memory/NSObject+MemoryAddress.swift
+++ b/Succinct/Memory/NSObject+MemoryAddress.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension NSObject {
     internal var memoryAddress: String {
         get {

--- a/Succinct/NSAttributedString/NSAttributedString+Attributes.swift
+++ b/Succinct/NSAttributedString/NSAttributedString+Attributes.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension NSAttributedString {
     @objc public func containsExactString(_ searchString: String, withAttributes searchAttributes: [NSAttributedString.Key : Any]) -> Bool {
         guard let matchingAttributes = findAttributeKeysMatching(searchAttributes, atSubstring: searchString) else {

--- a/Succinct/PrivateTypes/PrivateTypes.swift
+++ b/Succinct/PrivateTypes/PrivateTypes.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 class PrivateTypes {
     private struct Constants {
         struct ClassName {

--- a/Succinct/Succinct.h
+++ b/Succinct/Succinct.h
@@ -1,4 +1,4 @@
-#import <UIKit/UIKit.h>
+#import <Foundation/NSObjCRuntime.h>
 
 //! Project version number for Succinct.
 FOUNDATION_EXPORT double SuccinctVersionNumber;

--- a/Succinct/UIBarButtonItem/UIBarButtonItem+Extensions.swift
+++ b/Succinct/UIBarButtonItem/UIBarButtonItem+Extensions.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIBarButtonItem {
     ///
     /// Convenience property for accessing the `SystemItem` for this UIBarButtonItem, if one has been set.

--- a/Succinct/UIButton/UIButton+Tap.swift
+++ b/Succinct/UIButton/UIButton+Tap.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIButton {
     ///
     /// Simulates tapping a UIButton control by sending the `.touchUpInside` event action.

--- a/Succinct/UICollectionView/UICollectionView+Evaluations.swift
+++ b/Succinct/UICollectionView/UICollectionView+Evaluations.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UICollectionView {
     ///
     /// Searches through all cells of all sections within a UICollectionView for a cell that satisfies the passed in condition.

--- a/Succinct/UIControl/UIControl+Readability.swift
+++ b/Succinct/UIControl/UIControl+Readability.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIControl {
     ///
     /// Convenience method which indicates if the control is disabled or not. This can be helpful when writing assertions as opposed to testing the isEnabled property.

--- a/Succinct/UINavigationController/UINavigationController+UILabel.swift
+++ b/Succinct/UINavigationController/UINavigationController+UILabel.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UINavigationController {
     func hasLabelInNavigationBar(withExactText searchText: String) -> Bool? {
         if view.hasLabel(withExactText: searchText) {

--- a/Succinct/UINavigationItem/UINavigationItem+UIBarButtonItem.swift
+++ b/Succinct/UINavigationItem/UINavigationItem+UIBarButtonItem.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UINavigationItem {
     internal func findBarButtonItem(matchingCondition searchCondition: (_ item: UIBarButtonItem) -> Bool) -> UIBarButtonItem? {
         if let leftBarButtonItems = leftBarButtonItems {

--- a/Succinct/UIPickerView/UIPickerView+SelectComponent.swift
+++ b/Succinct/UIPickerView/UIPickerView+SelectComponent.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIPickerView {
     ///
     /// Loops through all components (columns) of a UIPickerView and searches the title text for each row of the current column for the specified search text. If a row title matching the search text is found, then that row will be selected.

--- a/Succinct/UISegmentedControl/UISegmentedControl+UISegmentLabel.swift
+++ b/Succinct/UISegmentedControl/UISegmentedControl+UISegmentLabel.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIView {
     func isUISegmentLabel() -> Bool {
         return self.isKind(of: PrivateTypes.UISegmentLabel)

--- a/Succinct/UISlider/UISlider+SetValue.swift
+++ b/Succinct/UISlider/UISlider+SetValue.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UISlider {
     @objc public func setValueAndFireTargetEvent(_ newValue: Float) {
         value = newValue

--- a/Succinct/UISwitch/UISwitch+Readability.swift
+++ b/Succinct/UISwitch/UISwitch+Readability.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UISwitch {
     ///
     /// Convenience property which indicates if the UISwitch is off. This can be helpful when writing assertions as opposed to testing the isOn property.

--- a/Succinct/UISwitch/UISwitch+Tap.swift
+++ b/Succinct/UISwitch/UISwitch+Tap.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UISwitch {
     ///
     /// Simulates tapping a UISwitch control by sending the `.touchUpInside` event action. Since simply sending the action does not change the state of the UISwitch, this method also flips the `isOn` property to simulate the effect tapping the switch would actually have.

--- a/Succinct/UITabBarController/UITabBarController+TabInteractions.swift
+++ b/Succinct/UITabBarController/UITabBarController+TabInteractions.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UITabBarController {
     ///
     /// Attempts to select a tab in a UITabBarController whose UITabBarItem `title` property matches the searchTitle text.

--- a/Succinct/UITableView/UITableView+Evaluations.swift
+++ b/Succinct/UITableView/UITableView+Evaluations.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 ///
 /// Definition for a closure that takes a UIView as an argument in order to evaluates it against some kind of condition. If a UIView object that satisfies this condition is found, then that UIView object is returned.
 ///

--- a/Succinct/UIView/UIButton/IsButtonWithExactText.swift
+++ b/Succinct/UIView/UIButton/IsButtonWithExactText.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 internal extension UIView {
     func isButton(withExactText searchText: String) -> EvaluationResult {
         guard let button = self as? UIButton else {

--- a/Succinct/UIView/UIButton/IsButtonWithImage.swift
+++ b/Succinct/UIView/UIButton/IsButtonWithImage.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 internal extension UIView {
     func isButton(withImage searchImage: UIImage) -> EvaluationResult {
         guard let button = self as? UIButton else {

--- a/Succinct/UIView/UIButton/UIView+UIButton.swift
+++ b/Succinct/UIView/UIButton/UIView+UIButton.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIView {
     ///
     /// Searches the entire view hierarchy of the current view for a UIButton whose title for `UIControl.State.normal` matches the searchText exactly.

--- a/Succinct/UIView/UIImage/IsImageViewWithImage.swift
+++ b/Succinct/UIView/UIImage/IsImageViewWithImage.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 internal extension UIView {
     func isImageView(withImage searchImage: UIImage) -> EvaluationResult {
         guard let imageView = self as? UIImageView else {

--- a/Succinct/UIView/UIImage/UIView+UIImage.swift
+++ b/Succinct/UIView/UIImage/UIView+UIImage.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIView {
     ///
     /// Searches the entire view hierarchy of the current view for a UIImageView object whose image matches the provided search image.

--- a/Succinct/UIView/UILabel/IsLabelContainingText.swift
+++ b/Succinct/UIView/UILabel/IsLabelContainingText.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 internal extension UIView {
     func isLabel(containingText searchText: String) -> EvaluationResult {
         if self.isUISegmentLabel() {

--- a/Succinct/UIView/UILabel/IsLabelWithExactText.swift
+++ b/Succinct/UIView/UILabel/IsLabelWithExactText.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 internal extension UIView {
     func isLabel(withExactText searchText: String) -> EvaluationResult {
         if self.isUISegmentLabel() {

--- a/Succinct/UIView/UILabel/UIView+UILabel.swift
+++ b/Succinct/UIView/UILabel/UIView+UILabel.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 // MARK: - Has UILabels
 extension UIView {
     ///

--- a/Succinct/UIView/UISegmentedControl/UIView+hasSegmentedControlSegmentSelected.swift
+++ b/Succinct/UIView/UISegmentedControl/UIView+hasSegmentedControlSegmentSelected.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 internal extension UIView {
     func isSegmentedControl() -> EvaluationResult {
         guard let _ = self as? UISegmentedControl else {

--- a/Succinct/UIView/UIView+Readability.swift
+++ b/Succinct/UIView/UIView+Readability.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIView {
     ///
     /// Convenience method which indicates if the view is visible or not. This can be helpful when writing assertions as opposed to testing the isHidden property.

--- a/Succinct/UIView/UIView+UIBarButtonItem.swift
+++ b/Succinct/UIView/UIView+UIBarButtonItem.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIView {
     ///
     /// Searches the entire view hierarchy of the current view for a UIToolbar which may contain a UIBarButtonItem whose `SystemItem` matches the searchSystemItem.

--- a/Succinct/UIView/UIView+UIDatePickerView.swift
+++ b/Succinct/UIView/UIView+UIDatePickerView.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIView {
     ///
     /// Searches the entire view hierarchy of the current view for a UIDatePicker object.

--- a/Succinct/UIView/UIView+UIPickerView.swift
+++ b/Succinct/UIView/UIView+UIPickerView.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIView {
     ///
     /// Searches the entire view hierarchy of the current view for any UIPickerView.

--- a/Succinct/UIView/UIView+UISegmentedControl.swift
+++ b/Succinct/UIView/UIView+UISegmentedControl.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIView {
     @objc public func hasSegmentedControlSegmentSelected(withExactText searchText: String) -> Bool {
         return findInSubviews(

--- a/Succinct/UIView/UIView+UISlider.swift
+++ b/Succinct/UIView/UIView+UISlider.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 // MARK: - Finding UISliders
 extension UIView {
     @objc public func findSlider(withValue searchValue: Float) -> UISlider? {

--- a/Succinct/UIView/UIView+UIStepper.swift
+++ b/Succinct/UIView/UIView+UIStepper.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIView {
     @objc public func hasStepper(currentCount: Int) -> Int {
         var thisLoopCount = currentCount

--- a/Succinct/UIView/UIView+UISwitch.swift
+++ b/Succinct/UIView/UIView+UISwitch.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIView {
     ///
     /// Searches the entire view hierarchy of the current view for all UISwitch objects whose `isOn` property matches the provided value.

--- a/Succinct/UIView/UIView+UITextField.swift
+++ b/Succinct/UIView/UIView+UITextField.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 // MARK: - Has UITextFields
 extension UIView {
     ///

--- a/Succinct/UIView/UIView+UITextView.swift
+++ b/Succinct/UIView/UIView+UITextView.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 // MARK: - Has UITextView
 extension UIView {
     ///

--- a/Succinct/UIView/UIView/UIView+countOfViewsWithBackgroundColor.swift
+++ b/Succinct/UIView/UIView/UIView+countOfViewsWithBackgroundColor.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIView {
     @objc public func countOfViews(withBackgroundColor searchColor: UIColor) -> Int {
         var viewsCounted = 0

--- a/Succinct/UIView/UIView/UIView+findInSubviews.swift
+++ b/Succinct/UIView/UIView/UIView+findInSubviews.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIView {
     internal func findInSubviews(
         satisfyingCondition condition: SuccinctCondition,

--- a/Succinct/UIView/UIView/UIView+hasViewWithBackgroundColor.swift
+++ b/Succinct/UIView/UIView/UIView+hasViewWithBackgroundColor.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIView {
     @objc public func hasView(withBackgroundColor searchColor: UIColor) -> Bool {
         if backgroundColor == searchColor {

--- a/Succinct/UIViewController/UIViewController+Debugging.swift
+++ b/Succinct/UIViewController/UIViewController+Debugging.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIViewController {
     internal func executeWithEnterAndExitDebugLog(closure: () -> UIView?) -> UIView? {
         let objectType = String(describing: type(of: self))

--- a/Succinct/UIViewController/UIViewController+Testing.swift
+++ b/Succinct/UIViewController/UIViewController+Testing.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIViewController {
     @objc public func loadViewControllerForUnitTest() {
         view.setNeedsLayout()

--- a/Succinct/UIViewController/UIViewController+UIBarButtonItem.swift
+++ b/Succinct/UIViewController/UIViewController+UIBarButtonItem.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIViewController {
     ///
     /// Searches the view controller's `navigationItem.leftBarButtonItems`, `navigationItem.rightBarButtonItems`, as well as the UIView hierarchy for a UIToolbar which may contain a UIBarButtonItem whose `SystemItem` matches the searchSystemItem and then attempts to tap the UIBarButtonItem by firing its associated target event, if one exists.

--- a/Succinct/UIViewController/UIViewController+UIButton.swift
+++ b/Succinct/UIViewController/UIViewController+UIButton.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 // MARK: - Searching by exact text
 extension UIViewController {
     ///

--- a/Succinct/UIViewController/UIViewController+UIDatePickerView.swift
+++ b/Succinct/UIViewController/UIViewController+UIDatePickerView.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIViewController {
     ///
     /// Searches the entire view hierarchy of a view controller's primary view for a UIDatePicker object.

--- a/Succinct/UIViewController/UIViewController+UIImage.swift
+++ b/Succinct/UIViewController/UIViewController+UIImage.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIViewController {
     ///
     /// Searches the entire view hierarchy of a view controller's primary view for a UIImageView object whose image matches the provided search image.

--- a/Succinct/UIViewController/UIViewController+UILabel.swift
+++ b/Succinct/UIViewController/UIViewController+UILabel.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 // MARK: - Has UILabel
 extension UIViewController {
     ///

--- a/Succinct/UIViewController/UIViewController+UIPickerView.swift
+++ b/Succinct/UIViewController/UIViewController+UIPickerView.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIViewController {
     ///
     /// Searches the entire view hierarchy of a view controller's primary view for any UIPickerView.

--- a/Succinct/UIViewController/UIViewController+UISegmentedControl.swift
+++ b/Succinct/UIViewController/UIViewController+UISegmentedControl.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIViewController {
     @objc public func hasSegmentedControlSegmentSelected(withExactText searchText: String) -> Bool {
         return view.hasSegmentedControlSegmentSelected(withExactText: searchText)

--- a/Succinct/UIViewController/UIViewController+UISlider.swift
+++ b/Succinct/UIViewController/UIViewController+UISlider.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIViewController {
     @objc public func hasSlider(withValue searchValue: Float) -> Bool {
         return view.hasSlider(withValue: searchValue)

--- a/Succinct/UIViewController/UIViewController+UIStepper.swift
+++ b/Succinct/UIViewController/UIViewController+UIStepper.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIViewController {
     @objc public func hasStepper(expectedCount: Int = 1) -> Bool {
         let stepperCount = view.hasStepper(currentCount: 0)

--- a/Succinct/UIViewController/UIViewController+UISwitch.swift
+++ b/Succinct/UIViewController/UIViewController+UISwitch.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIViewController {
     ///
     /// Searches the entire view hierarchy of a view controller's primary view for all UISwitch objects whose `isOn` property matches the provided value.

--- a/Succinct/UIViewController/UIViewController+UITableView.swift
+++ b/Succinct/UIViewController/UIViewController+UITableView.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIViewController {
     ///
     /// Searches the entire view hierarchy of a view controller's primary view for any UITableView objects to determine if there is a selected UITableViewCell within that UITableView.

--- a/Succinct/UIViewController/UIViewController+UITextField.swift
+++ b/Succinct/UIViewController/UIViewController+UITextField.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 // MARK: - Has UITextField
 extension UIViewController {
     ///

--- a/Succinct/UIViewController/UIViewController+UITextView.swift
+++ b/Succinct/UIViewController/UIViewController+UITextView.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 // MARK: - Has UITextView
 extension UIViewController {
     ///

--- a/Succinct/UIViewController/UIViewController+UIView.swift
+++ b/Succinct/UIViewController/UIViewController+UIView.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 extension UIViewController {
     ///
     /// Searches the entire view hierarchy of a view controller's primary view for a UIView whose background color matches the searchColor.

--- a/SuccinctContainerTests/UIViewController/UIViewController+UIBarButtonItemSpec.swift
+++ b/SuccinctContainerTests/UIViewController/UIViewController+UIBarButtonItemSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 @testable import Succinct

--- a/SuccinctContainerTests/UIViewController/UIViewController+UIButtonSpec.swift
+++ b/SuccinctContainerTests/UIViewController/UIViewController+UIButtonSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 @testable import Succinct

--- a/SuccinctContainerTests/UIViewController/UIViewController+UISliderSpec.swift
+++ b/SuccinctContainerTests/UIViewController/UIViewController+UISliderSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctContainerTests/UIViewController/UIViewController+UISwitchSpec.swift
+++ b/SuccinctContainerTests/UIViewController/UIViewController+UISwitchSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 @testable import Succinct

--- a/SuccinctTests/DebugLogging/UIView/DebugLogging+MKMapViewSpec.swift
+++ b/SuccinctTests/DebugLogging/UIView/DebugLogging+MKMapViewSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 @testable import Succinct

--- a/SuccinctTests/DebugLogging/UIView/DebugLogging+UIDatePickerViewSpec.swift
+++ b/SuccinctTests/DebugLogging/UIView/DebugLogging+UIDatePickerViewSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 @testable import Succinct

--- a/SuccinctTests/DebugLogging/UIView/DebugLogging+UIPickerViewSpec.swift
+++ b/SuccinctTests/DebugLogging/UIView/DebugLogging+UIPickerViewSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 @testable import Succinct

--- a/SuccinctTests/DebugLogging/UIView/DebugLogging+UIViewSpec.swift
+++ b/SuccinctTests/DebugLogging/UIView/DebugLogging+UIViewSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 @testable import Succinct

--- a/SuccinctTests/DebugLogging/UIView/UIButton/DebugLogging+UIButtonSpec.swift
+++ b/SuccinctTests/DebugLogging/UIView/UIButton/DebugLogging+UIButtonSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 @testable import Succinct

--- a/SuccinctTests/DebugLogging/UIView/UILabel/DebugLogging+UILabelSpec.swift
+++ b/SuccinctTests/DebugLogging/UIView/UILabel/DebugLogging+UILabelSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 @testable import Succinct

--- a/SuccinctTests/DebugLogging/UIViewController/DebugLogging+UIViewController+UIButton.swift
+++ b/SuccinctTests/DebugLogging/UIViewController/DebugLogging+UIViewController+UIButton.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 @testable import Succinct

--- a/SuccinctTests/UILabel/UITableViewController+findingUILabel.swift
+++ b/SuccinctTests/UILabel/UITableViewController+findingUILabel.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctTests/UIPickerView/UIPickerView+SelectComponentSpec.swift
+++ b/SuccinctTests/UIPickerView/UIPickerView+SelectComponentSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctTests/UIPickerView/UIViewController+UIPickerViewSpec.swift
+++ b/SuccinctTests/UIPickerView/UIViewController+UIPickerViewSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctTests/UITabBarController/UITabBarController+TabInteractionsSpec.swift
+++ b/SuccinctTests/UITabBarController/UITabBarController+TabInteractionsSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctTests/UITableView/UITableViewConfigurationSpec.swift
+++ b/SuccinctTests/UITableView/UITableViewConfigurationSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctTests/UIViewController/UIViewController+UIButton+findButtonSpec.swift
+++ b/SuccinctTests/UIViewController/UIViewController+UIButton+findButtonSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctTests/UIViewController/UIViewController+UIButton+findButtonsSpec.swift
+++ b/SuccinctTests/UIViewController/UIViewController+UIButton+findButtonsSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctTests/UIViewController/UIViewController+UIButton+hasButtonSpec.swift
+++ b/SuccinctTests/UIViewController/UIViewController+UIButton+hasButtonSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctTests/UIViewController/UIViewController+UIDatePickerSpec.swift
+++ b/SuccinctTests/UIViewController/UIViewController+UIDatePickerSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctTests/UIViewController/UIViewController+UIImageViewSpec.swift
+++ b/SuccinctTests/UIViewController/UIViewController+UIImageViewSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctTests/UIViewController/UIViewController+UILabelSpec.swift
+++ b/SuccinctTests/UIViewController/UIViewController+UILabelSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctTests/UIViewController/UIViewController+UISegmentedControlSpec.swift
+++ b/SuccinctTests/UIViewController/UIViewController+UISegmentedControlSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctTests/UIViewController/UIViewController+UISwitchSpec.swift
+++ b/SuccinctTests/UIViewController/UIViewController+UISwitchSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctTests/UIViewController/UIViewController+UITableViewSpec.swift
+++ b/SuccinctTests/UIViewController/UIViewController+UITableViewSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctTests/UIViewController/UIViewController+UITextFieldSpec.swift
+++ b/SuccinctTests/UIViewController/UIViewController+UITextFieldSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct

--- a/SuccinctTests/UIViewController/UIViewController+UITextViewSpec.swift
+++ b/SuccinctTests/UIViewController/UIViewController+UITextViewSpec.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Quick
 import Nimble
 import Succinct


### PR DESCRIPTION
This adds support for Swift Package Manager!

- Adds a `Package.swift` which adds the `Succinct` and `SuccinctTests` targets. The `SuccinctContainer` and its tests were not added as they don't need to be exposed to users of the library. 

- Added instructions in the Readme. Couldn't find a badge for the Swift Package Manager unfortunately!

- Inititally, there were build errors via SPM because the `import <UIKit/UIKit.h>` in `Succinct.h` wasn't having any effect. From what I could tell, there isn't an easy way to fix this (found some mention of it [here](https://stackoverflow.com/questions/34778823/swift-package-manager-uikit-dependency/67253485#67253485)). To get around this, imports from UIKit or Foundation were added to any file that used UIKit or Foundation (most of them). I also changed the import in `Succinct.h` to not import the `FOUNDATION_EXPORT` macro not from UIKit.h but another more specific header to make sure it's not possible to forget to import UIKit or Foundation. See this [stack overflow answer](https://stackoverflow.com/a/19195224) for more details.